### PR TITLE
Add diagonal Coulomb to Strang

### DIFF
--- a/mec_sandia/product_formulas/grid_ham_diagonal_coulomb_test.py
+++ b/mec_sandia/product_formulas/grid_ham_diagonal_coulomb_test.py
@@ -1,0 +1,78 @@
+"""
+Test the time-evolution with full 2-electron integrals and Diagonal Coulomb. 
+
+The Diagonal Coulomb should be faster
+"""
+import sys
+import numpy as np
+
+import fqe
+from fqe.openfermion_utils import integrals_to_fqe_restricted
+from fqe.hamiltonians.restricted_hamiltonian import RestrictedHamiltonian
+from fqe.hamiltonians.diagonal_coulomb import DiagonalCoulomb
+
+from mec_sandia.product_formulas.systems.real_space_grid import RealSpaceGrid 
+from mec_sandia.product_formulas.time_evolution_utility import apply_unitary_wrapper
+from mec_sandia.product_formulas.spectral_norm_product import spectral_norm_fqe_power_iteration
+from mec_sandia.product_formulas.strang import delta_action
+
+
+def run_spectral_norm_comp(t: float, points_per_dim: int, eta: int, omega: float):
+    L = omega**(1/3)
+    rsg = RealSpaceGrid(L, points_per_dim)
+    h1 = rsg.get_rspace_h1()
+    eris = 2 * rsg.get_eris()
+    of_eris = eris.transpose((0, 2, 3, 1))
+    dc_mat = 2 * rsg.get_diagonal_coulomb_matrix()
+    if np.isclose(eta % 2, 1):
+        sz = 1
+    else:
+        sz = 0
+    nelec = eta
+    norb = rsg.norb
+
+    fqe_ham = integrals_to_fqe_restricted(h1, of_eris)    
+    fqe_ham_ob = RestrictedHamiltonian((h1,))
+    fqe_ham_tb = RestrictedHamiltonian((np.zeros_like(h1), np.einsum('ijlk', -0.5 * of_eris)))
+    fqe_ham_tb_dc = DiagonalCoulomb(np.einsum('ijlk', -0.5 * of_eris))
+    fqe_ham_tb_dc_v2 = DiagonalCoulomb(0.5 * dc_mat)
+
+     # initialize new wavefunction
+    x_wfn = fqe.Wavefunction([[nelec, sz, norb]])
+    x_wfn.set_wfn(strategy='random')
+    x_wfn.normalize()
+
+    import time
+    # calculate spectral norm
+    start_time = time.time()
+    full_two_body_wfn = apply_unitary_wrapper(base=x_wfn,
+                                     time=t,
+                                     algo='taylor',
+                                     ops=fqe_ham_tb,
+                                     accuracy = 1.0E-20,
+                                     expansion=300,
+                                     verbose=True)
+    end_time = time.time()
+    print("full-two-body time {}".format(end_time - start_time))
+    start_time = time.time()
+    dc_wfn = x_wfn.time_evolve(t, fqe_ham_tb_dc)
+    end_time = time.time()
+    print("DiagonalCoulomb time {}".format(end_time - start_time))
+    diff_wfn = full_two_body_wfn - dc_wfn
+    print(f"{np.linalg.norm(diff_wfn.sector((nelec, sz)).coeff)=}")
+
+    start_time = time.time()
+    dc_wfn_v2 = x_wfn.time_evolve(t, fqe_ham_tb_dc_v2)
+    end_time = time.time()
+    print("DiagonalCoulomb-v2 time {}".format(end_time - start_time))
+    diff_wfn = full_two_body_wfn - dc_wfn_v2
+    print(f"{np.linalg.norm(diff_wfn.sector((nelec, sz)).coeff)=}")
+
+
+if __name__ == "__main__":
+    # python -u /home/nickrubin_google_com/trotter_scaling/grid/grid_ham_strang_spectral_norm_exe.py 0.65 2 4 5.0
+    t = 0.25
+    ppd = 2
+    eta = 3
+    omega = 3.0
+    run_spectral_norm_comp(t, ppd, eta, omega)

--- a/mec_sandia/product_formulas/spectral_norm_product.py
+++ b/mec_sandia/product_formulas/spectral_norm_product.py
@@ -1,10 +1,12 @@
 """
 Calculate the spectral norm of the difference between a product formula and the exact unitary.
 """
+from typing import Callable, Union
 import time
 import numpy as np
 import fqe
 from fqe.hamiltonians.restricted_hamiltonian import RestrictedHamiltonian
+from fqe.hamiltonians.diagonal_coulomb import DiagonalCoulomb
 
 def spectral_norm_power_method(A, x, verbose=False, stop_eps=1.0E-8, return_vec=False):
     """
@@ -69,8 +71,8 @@ def spectral_norm_fqe_power_iteration(work: fqe.Wavefunction,
                         t: float,
                         full_ham: RestrictedHamiltonian,
                         h0: RestrictedHamiltonian,
-                        h1: RestrictedHamiltonian,
-                        delta_action,
+                        h1: Union[RestrictedHamiltonian, DiagonalCoulomb],
+                        delta_action: Callable,
                         verbose=True,
                         stop_eps=1.0E-8) -> float:
     """Return spectral norm of the difference between product formula unitary and exact unitary

--- a/mec_sandia/product_formulas/strang.py
+++ b/mec_sandia/product_formulas/strang.py
@@ -1,20 +1,32 @@
 """Get the Jellium Hamiltonian as an FQE-Hamiltonian"""
+from typing import Union
 import copy
+import time
+
 import fqe
 from fqe.hamiltonians.restricted_hamiltonian import RestrictedHamiltonian
+from fqe.hamiltonians.diagonal_coulomb import DiagonalCoulomb
+
 from mec_sandia.product_formulas.time_evolution_utility import apply_unitary_wrapper
+
 MAX_EXPANSION_LIMIT = 200
 
-def strang_u(work: fqe.Wavefunction, t: float, fqe_ham_ob: RestrictedHamiltonian, fqe_ham_tb: RestrictedHamiltonian ):
+def strang_u(work: fqe.Wavefunction, t: float, fqe_ham_ob: RestrictedHamiltonian, fqe_ham_tb: Union[RestrictedHamiltonian, DiagonalCoulomb] ):
     """Strang split-operator evolution"""
     work = work.time_evolve(t * 0.5, fqe_ham_ob)
-    work = apply_unitary_wrapper(base=work,
-                                 time=t,
-                                 algo='taylor',
-                                 ops=fqe_ham_tb,
-                                 accuracy=1.0E-20,
-                                 expansion=MAX_EXPANSION_LIMIT,
-                                 verbose=False)
+    if isinstance(fqe_ham_tb, DiagonalCoulomb):
+        print("Using diagonal coulomb evolution")
+        work = work.time_evolve(t, fqe_ham_tb)
+    elif isinstance(fqe_ham_tb, RestrictedHamiltonian):
+        work = apply_unitary_wrapper(base=work,
+                                     time=t,
+                                     algo='taylor',
+                                     ops=fqe_ham_tb,
+                                     accuracy=1.0E-20,
+                                     expansion=MAX_EXPANSION_LIMIT,
+                                     verbose=False)
+    else:
+        raise TypeError("The two-body Hamiltonian does not have an allowed type {}".format(type(fqe_ham_tb)))
     work = work.time_evolve(t * 0.5, fqe_ham_ob)
     return work
 
@@ -82,17 +94,28 @@ def delta_action(work: fqe.Wavefunction,
     if work.norm() - 1. > 1.0E-14:
         print(f"{work.norm()=}", f"{(work.norm() - 1.)=}")
         raise RuntimeError("Input wavefunction wrong norm")
+
+    start_time = time.time()
     product_wf = strang_u(copy.deepcopy(work), t, h0, h1)
+    end_time = time.time()
+
+    print("Strang u time ", end_time - start_time)
+
     if product_wf.norm() - 1. > 1.0E-14:
         print(f"{product_wf.norm()=}", f"{(product_wf.norm() - 1.)=}")
         raise RuntimeError("Evolution did not converge")
+    
+    start_time = time.time()
     exact_wf = apply_unitary_wrapper(base=work,
                                      time=t,
                                      algo='taylor',
                                      ops=full_ham,
                                      accuracy = 1.0E-20,
                                      expansion=MAX_EXPANSION_LIMIT,
-                                     verbose=False)
+                                     verbose=False,
+                                     debug=False)
+    end_time = time.time()
+    print("exact u time ", end_time - start_time)
     return product_wf - exact_wf
 
 

--- a/mec_sandia/product_formulas/systems/real_space_grid.py
+++ b/mec_sandia/product_formulas/systems/real_space_grid.py
@@ -93,6 +93,26 @@ class RealSpaceGrid:
 
         eris *= self.points_per_dim / (2 * self.L)
         return eris
+    
+    def get_diagonal_coulomb_matrix(self):
+        """
+        Get diagonal coulomb matrix specifying
+        V = sum_{rs}v_{rs}n_{r}n_{s}
+        The factor of 1/2 is ALREADY included in this
+        """
+        ijk_vals = self.get_miller()
+        norb = len(ijk_vals)
+        distance_mat = np.zeros((norb, norb))
+        for l, m in itertools.product(range(len(ijk_vals)), repeat=2):
+            distance_mat[l, m] = np.linalg.norm(ijk_vals[l] - ijk_vals[m])
+        distance_mat = np.reciprocal(distance_mat, 
+                                     out=np.zeros_like(distance_mat), 
+                                     where=~np.isclose(distance_mat, 
+                                                       np.zeros_like(distance_mat)
+                                                       )
+        )
+        return distance_mat * self.points_per_dim / (2 * self.L)
+
 
     def fourier_transform_matrix(self):
         """position space to momentum space

--- a/mec_sandia/product_formulas/systems/real_space_grid_test.py
+++ b/mec_sandia/product_formulas/systems/real_space_grid_test.py
@@ -54,3 +54,18 @@ def test_even_number_points():
     rsg = RealSpaceGrid(5, 4)
     u = rsg.fourier_transform_matrix()
     assert np.allclose(u.conj().T @ u, np.eye(4**3))
+
+def test_diagonal_coulomb_matrix():
+    rsg = RealSpaceGrid(5, 3)
+    eris = 2 * rsg.get_eris()
+    of_eris = eris.transpose((0, 2, 3, 1))
+    dc_mat = 2 * rsg.get_diagonal_coulomb_matrix()
+    for l, m in itertools.product(range(rsg.norb), repeat=2):
+        assert np.isclose(eris[l, l, m, m], dc_mat[l, m])
+
+    from fqe.hamiltonians.diagonal_coulomb import DiagonalCoulomb
+    tb_dc = DiagonalCoulomb(np.einsum('ijlk', -0.5 * of_eris))
+    tb_dc_v2 = DiagonalCoulomb(0.5 * dc_mat)
+    assert np.allclose(tb_dc._tensor[1], 0)
+    assert np.allclose(tb_dc._tensor[2], 0.5 * dc_mat)
+    assert np.allclose(tb_dc._tensor[2], tb_dc_v2._tensor[2])

--- a/mec_sandia/product_formulas/time_evolution_utility.py
+++ b/mec_sandia/product_formulas/time_evolution_utility.py
@@ -15,17 +15,21 @@ def apply_unitary_wrapper(base: fqe.Wavefunction, time: float, algo, ops: hamilt
     for op_coeff_tensor in ops.iht(time):
         upper_bound_norm += np.sum(np.abs(op_coeff_tensor))
         norm_of_coeffs.append(np.linalg.norm(op_coeff_tensor))
+
     if upper_bound_norm >= smallest_time_slice:
         num_slices = int(np.ceil(upper_bound_norm / smallest_time_slice))
         time_evol = copy.deepcopy(base)
-        # print("Using {} slices to evolve for {} time".format(num_slices, time), norm_of_coeffs)
         if debug:
+            print("Using {} slices to evolve for {} time".format(num_slices, time), norm_of_coeffs)
             if time_evol.norm() - 1. > NORM_ERROR_RESOLUTION:
                 print("pre-slice-start", f"{time_evol.norm()=}", f"{(time_evol.norm() - 1.)=}")
                 raise RuntimeError("Evolution did not converge")
 
         total_time = 0
         for mm in range(num_slices):
+            if debug:
+                print("Slice ", f"{mm=}")
+
             time_evol = time_evol.apply_generated_unitary(
                 time=time / num_slices, algo=algo, ops=ops, accuracy=accuracy, expansion=expansion,
                                                 verbose=verbose

--- a/trotter_scaling/suzuki_4_example.py
+++ b/trotter_scaling/suzuki_4_example.py
@@ -1,19 +1,16 @@
 """
 Grid Hamiltonian spectral norm computation executable
 """
-import os
-os.environ['MKL_NUM_THREADS'] = '4'
 import sys
 import numpy as np
 
 import fqe
 from fqe.openfermion_utils import integrals_to_fqe_restricted
 from fqe.hamiltonians.restricted_hamiltonian import RestrictedHamiltonian
-from fqe.hamiltonians.diagonal_coulomb import DiagonalCoulomb
 
 from mec_sandia.product_formulas.systems.real_space_grid import RealSpaceGrid 
 from mec_sandia.product_formulas.spectral_norm_product import spectral_norm_fqe_power_iteration
-from mec_sandia.product_formulas.strang import delta_action
+from mec_sandia.product_formulas.suzuki import delta_action_4 as delta_action
 
 
 def run_spectral_norm_comp(t: float, points_per_dim: int, eta: int, omega: float):
@@ -21,7 +18,6 @@ def run_spectral_norm_comp(t: float, points_per_dim: int, eta: int, omega: float
     rsg = RealSpaceGrid(L, points_per_dim)
     h1 = rsg.get_rspace_h1()
     eris = 2 * rsg.get_eris()
-    dc_mat = 2 * rsg.get_diagonal_coulomb_matrix()
     of_eris = eris.transpose((0, 2, 3, 1))
     if np.isclose(eta % 2, 1):
         sz = 1
@@ -33,7 +29,6 @@ def run_spectral_norm_comp(t: float, points_per_dim: int, eta: int, omega: float
     fqe_ham = integrals_to_fqe_restricted(h1, of_eris)    
     fqe_ham_ob = RestrictedHamiltonian((h1,))
     fqe_ham_tb = RestrictedHamiltonian((np.zeros_like(h1), np.einsum('ijlk', -0.5 * of_eris)))
-    # fqe_ham_tb = DiagonalCoulomb(0.5 * dc_mat)
 
      # initialize new wavefunction
     x_wfn = fqe.Wavefunction([[nelec, sz, norb]])
@@ -49,11 +44,12 @@ def run_spectral_norm_comp(t: float, points_per_dim: int, eta: int, omega: float
                                                       delta_action=delta_action,
                                                       verbose=True,
                                                       stop_eps=1.0E-10)
-    np.save("spectral_norm.npy", np.array(spectral_norm))
+    np.save("spectral_norm_suzuki_4.npy", np.array(spectral_norm))
 
 if __name__ == "__main__":
-    t = float(sys.argv[1])
-    ppd = int(sys.argv[2])
-    eta = int(sys.argv[3])
-    omega = float(sys.argv[4])
+    # 0.65 2 3 5.0
+    t = 0.65 # float(sys.argv[1])
+    ppd = 2 # int(sys.argv[2])
+    eta = 3 # int(sys.argv[3])
+    omega = 5.0 # float(sys.argv[4])
     run_spectral_norm_comp(t, ppd, eta, omega)


### PR DESCRIPTION
This should speed up the product formula calculations by 2-3 orders of magnitude. Only applicable to the grid Hamiltonian where you have a diagonal coulomb Hamiltonian. First implementation is for the strang splitting